### PR TITLE
CGB - include/mixr/otw/cigi/CigiClNetwork.hpp : moved msgIn, msgOut ,…

### DIFF
--- a/include/mixr/otw/cigi/CigiClNetwork.hpp
+++ b/include/mixr/otw/cigi/CigiClNetwork.hpp
@@ -69,9 +69,16 @@ public:
    virtual void addPacketHatHotReq(CigiHatHotReqV3* const p) override;
    virtual void addPacketLosRangeReq(CigiLosVectReqV3* const p) override;
 
+   CigiIncomingMsg* getCigiIncomingMsg() { return msgIn; };
+   CigiOutgoingMsg* getCigiOutgoingMsg() { return msgOut; };
+
 protected:
    bool createCigiProcess();        // Create the CIGI network thread
    bool initCigiNetwork();          // Initialize the network
+
+   CigiIncomingMsg* msgIn {};
+   CigiOutgoingMsg* msgOut {};
+   CigiClNetworkSignalProcessing* sigProcessor {};
 
 private:
    base::safe_ptr<base::NetHandler> netInput;   // Input network handler
@@ -79,10 +86,6 @@ private:
    base::safe_ptr<base::Thread> thread;         // The thread
    bool networkInitialized {};                  // CIGI has been initialized
    bool networkInitFailed {};                   // CIGI initialization has failed
-
-   CigiIncomingMsg* msgIn {};
-   CigiOutgoingMsg* msgOut {};
-   CigiClNetworkSignalProcessing* sigProcessor {};
 };
 
 }

--- a/src/interop/common/Nib.cpp
+++ b/src/interop/common/Nib.cpp
@@ -934,8 +934,14 @@ bool Nib::mainDeadReckoning(
       }
       break;
 
+      // No dead reckoning
+      case STATIC_DRM: {
+         *pNewP0 = drP0;
+         *pNewRPY = drRPY0;
+      }
+      break;
+
       case OTHER_DRM:   // User defined
-      case STATIC_DRM:  // No dead reckoning
       default:          // default
          std::cout << "drNum == default" << std::endl;
          *pNewP0 = drP0;


### PR DESCRIPTION
… and sigProcesser to protected so they can be used in sub-classes. Also, exposed them with inline accessor functions.

CGB - src/interop/common/Nib.cpp : STATIC_DRM is a valid DRM. Rearranged cases so STATIC_DRM does not print warning message.